### PR TITLE
PRMP-1210

### DIFF
--- a/Dojofile-py
+++ b/Dojofile-py
@@ -1,1 +1,1 @@
-DOJO_DOCKER_IMAGE="nhsdev/mhs-python-dojo:c0e1a9f1f5d2323dcf135d4114063ff0739382d3"
+DOJO_DOCKER_IMAGE="nhsdev/mhs-python-dojo:c9cc1e8410599cd2c9252f4f67c7f21d43765800"

--- a/tasks
+++ b/tasks
@@ -135,7 +135,7 @@ case "${command}" in
     docker build \
      --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG \
      -t mhs-${IMAGE_PREFIX}:$BUILD_TAG \
-     -f mhs/$DOCKER_DIRECTORY/Dockerfile .
+     -f docker/$DOCKER_DIRECTORY/Dockerfile .
 
     echo Built their image in $PWD, moving back to mhs-ci repo dir $PRM_REPO_MHS_DIR
     cd $PRM_REPO_MHS_DIR
@@ -166,7 +166,7 @@ case "${command}" in
     fi
     MHS_DIRECTORY=$MHS_COMPONENT
     cd $INTEGRATION_ADAPTORS_MHS_REPO_DIRECTORY
-    dojo -c ${PRM_REPO_MHS_DIR}/Dojofile-py "cd mhs/$MHS_DIRECTORY && pipenv install --dev && pipenv run unittests"
+    dojo -c ${PRM_REPO_MHS_DIR}/Dojofile-py "cd docker/$MHS_DIRECTORY && pipenv install --dev && pipenv run unittests"
     ;;
   *)
       echo "Invalid command: '${command}'"


### PR DESCRIPTION
- Use latest version of mhs-python-dojo docker image (Python v3.9)
- Modify directory from 'mhs' to 'docker' in-line with the changes in integration-adaptor-mhs release v1.3.2.